### PR TITLE
bug fix: multiple clicks on seek bar

### DIFF
--- a/src/components/AVPlayerRMP/AVCenteredPlay.js
+++ b/src/components/AVPlayerRMP/AVCenteredPlay.js
@@ -18,7 +18,8 @@ class AVCenteredPlay extends Component {
   }
 
   handlePlayPause = () => {
-    this.props.media.playPause();
+    if (!this.props.media.isLoading)
+      this.props.media.playPause();
   };
 
   render() {

--- a/src/components/AVPlayerRMP/AVPlayPause.js
+++ b/src/components/AVPlayerRMP/AVPlayPause.js
@@ -33,7 +33,8 @@ class AVPlayPause extends Component {
   }
 
   handlePlayPause = () => {
-    this.props.media.playPause();
+     if (!this.props.media.isLoading)
+      this.props.media.playPause();
   };
 
   render() {

--- a/src/components/AVPlayerRMP/AVPlayerRMP.js
+++ b/src/components/AVPlayerRMP/AVPlayerRMP.js
@@ -199,7 +199,8 @@ class AVPlayerRMP extends PureComponent {
 
   onKeyDown = (e) => {
     if (e.keyCode === 32) {
-      this.props.media.playPause();
+      if (!this.props.media.isLoading)
+        this.props.media.playPause();
       e.preventDefault();
     }
   };
@@ -362,12 +363,13 @@ class AVPlayerRMP extends PureComponent {
   };
 
   playPause = () => {
-    const { isMobile, media: { playPause } } = this.props;
+    const { isMobile, media } = this.props;
 
     if (isMobile && !this.state.controlsVisible) {
       this.showControls(() => this.hideControlsTimeout());
     } else {
-      playPause();
+      if (!media.isLoading)
+        media.playPause();
     }
   };
 

--- a/src/components/AVPlayerRMP/AvSeekBar.js
+++ b/src/components/AVPlayerRMP/AvSeekBar.js
@@ -153,8 +153,6 @@ class AvSeekBar extends Component {
     this.wasMouseDown         = true;
     this.isPlayingOnMouseDown = this.props.media.isPlaying;
 
-    this.props.media.pause();
-
     if (this.sliceStartHandle && e.target === this.sliceStartHandle.getKnobElement()) {
       this.sliceStartActive = true;
     } else if (this.sliceEndHandle && e.target === this.sliceEndHandle.getKnobElement()) {
@@ -202,18 +200,10 @@ class AvSeekBar extends Component {
 
       if (typeof clientX !== 'undefined') {
         // pause when dragging handles
-        if (this.sliceStartActive === true || this.sliceEndActive === true) {
-          this.props.media.pause();
-        }
 
         const seekPosition = this.getSeekPositionFromClientX(clientX);
         media.seekTo(seekPosition);
         this.setState({ playPoint: seekPosition });
-      }
-
-      // only play if media was playing prior to mouseDown
-      if (!this.sliceStartActive && !this.sliceEndActive && this.isPlayingOnMouseDown) {
-        this.props.media.play();
       }
 
       this.sliceStartActive = false;


### PR DESCRIPTION
caused because we pause and play when seeking.
There is no need do pause/play manually,
the player knows to play again automatically after the loading is done