### PR TITLE
fix video/audio player language dropdown css

### DIFF
--- a/src/stylesheets/includes/_not-sorted-scss.scss
+++ b/src/stylesheets/includes/_not-sorted-scss.scss
@@ -114,3 +114,7 @@ em {
     }
   }
 }
+/* limit the height of the media player languages dropdown in order to not get out of the screen */
+.mediaplayer__languages .ui.floating.dropdown>.menu {
+	max-height:220px;
+}


### PR DESCRIPTION
limit the height of the media player languages dropdown in order to not get out of the screen