### PR TITLE
fix omni box search filter

### DIFF
--- a/src/components/Search/OmniBox.js
+++ b/src/components/Search/OmniBox.js
@@ -95,7 +95,10 @@ export class OmniBox extends Component {
       // In case a filter was updated React location object is not updated yet
       // so we just use window location to get the search part (to persist filters
       // to the search page when we redirect).
-      push({ pathname: 'search', search: window.location.search });
+
+      // 'search: window.location.search' has been removed because 
+      // filters are not cleared when searching from a section (see bug AR-234)
+      push({ pathname: 'search'/*, search: window.location.search */});
     }
 
     // Reset filters for new search (query changed)


### PR DESCRIPTION
do not save previous filters when searching in the omni box search