### PR TITLE
fix share url for latest lesson

### DIFF
--- a/src/components/AVPlayer/AVPlayer.js
+++ b/src/components/AVPlayer/AVPlayer.js
@@ -470,6 +470,13 @@ class AVPlayer extends PureComponent {
     }
   };
 
+  // Get the video share url from shareUrl or from current address if shareUrl not found
+  getShareUrl = () => {
+    return (this.props && this.props.item && this.props.item.shareUrl) ?
+    window.location.origin + this.props.item.shareUrl + window.location.search : 
+    window.location.href;
+  };
+
   render() {
     const {
             autoPlay,
@@ -524,7 +531,7 @@ class AVPlayer extends PureComponent {
             icon="chevron left"
             onClick={this.handleToggleMode}
           />
-          <ShareBar url={window.location.href} t={t} />
+          <ShareBar url={this.getShareUrl()} t={t} />
         </div>
       );
     } else if (isVideo) {

--- a/src/helpers/player.js
+++ b/src/helpers/player.js
@@ -20,7 +20,7 @@ import {
   VS_DEFAULT,
 } from './consts';
 import { getQuery, updateQuery } from './url';
-import { isEmpty, physicalFile } from './utils';
+import { isEmpty, physicalFile, canonicalLink } from './utils';
 
 const fallbacksLanguages = [LANG_ENGLISH, LANG_HEBREW, LANG_RUSSIAN];
 
@@ -204,7 +204,12 @@ function playlist(collection, mediaType, language) {
       return acc.concat(v);
     }, []);
   } else {
-    items = units.map(x => playableItem(x, mediaType, language));
+    items = units.map(x => {
+      const p = playableItem(x, mediaType, language);
+      if (p.unit)
+        p.shareUrl = canonicalLink(p.unit);
+      return p;
+    });
   }
 
   return {


### PR DESCRIPTION
1. added a new varible "shaeUrl" for each item in the play list
2. check if we have "shareUrl" when sharing the video and use it or use window.location.href as before.