### PR TITLE
AR-364 Player [IE-11,Edge]-video does not load when you open it via link

### DIFF
--- a/src/components/AVPlayer/AVPlayer.js
+++ b/src/components/AVPlayer/AVPlayer.js
@@ -65,6 +65,8 @@ class AVPlayer extends PureComponent {
     onPause: PropTypes.func,
     onPrev: PropTypes.func,
     onNext: PropTypes.func,
+
+    deviceInfo: shapes.UserAgentParserResults.isRequired,
   };
 
   static defaultProps = {
@@ -120,11 +122,20 @@ class AVPlayer extends PureComponent {
         sliceEnd: send
       });
     }
-
-    this.setState({
-      firstSeek:true,
-      ...this.chooseSource(this.props)
-    });
+    if (this.props.deviceInfo.browser.name !== 'Edge' && 
+        this.props.deviceInfo.browser.name !== 'IE') {
+      this.setState({
+        firstSeek:true,
+        ...this.chooseSource(this.props)
+      }); 
+    } else {
+      setTimeout(() => {
+        this.setState({
+          firstSeek:true,
+          ...this.chooseSource(this.props)
+        }); 
+      }, 1);
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Added timeout on choose source when the browser is Edge or IE.
As far as i can see, this is not effecting the view source HTML for search engine.