### PR TITLE
AR-324 when open this section the scroll position is not on top

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -11,6 +11,9 @@ import '../../stylesheets/Kmedia.css';
 class App extends Component {
   render() {
     const { i18n, store, history, initialI18nStore, initialLanguage } = this.props;
+    if (document.activeElement) {
+      document.activeElement.blur();
+    }
     return (
       <I18nextProvider i18n={i18n} initialI18nStore={initialI18nStore} initialLanguage={initialLanguage}>
         <Provider store={store}>


### PR DESCRIPTION
The bug was happening because the browser saves the current active element (when navigate via the tab key) even when we close and reopen the browser.
The solution is to clear the active element when the page first loads.